### PR TITLE
Enable safe-string + switch to jbuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.merlin
+_build
+*.install

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-all:
-	ocamlbuild -I src arg.cma arg.cmxa
-
-clean:
-	ocamlbuild -clean

--- a/arg.opam
+++ b/arg.opam
@@ -1,0 +1,5 @@
+opam-version: "1"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://github.com/samoht/ocaml-arg"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+depends: ["jbuilder" {build & >= "1.0+beta20"}]

--- a/src/arg.mllib
+++ b/src/arg.mllib
@@ -1,3 +1,0 @@
-ArgExt
-FormatExt
-SubCommand

--- a/src/formatExt.ml
+++ b/src/formatExt.ml
@@ -35,9 +35,9 @@ let pp_print_list pp_elem sep fmt = function
       tl
 
 let pp_print_justified size fmt s =
-  let tmp = String.make size ' ' in
+  let tmp = Bytes.make size ' ' in
   String.blit s 0 tmp 0 (String.length s);
-  pp_print_string fmt tmp
+  pp_print_string fmt (Bytes.unsafe_to_string tmp)
 
 let pp_print_underlined c fmt s =
   pp_print_string fmt s;

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,0 +1,4 @@
+(library
+ ((name arg)
+  (public_name arg)
+  (wrapped false)))


### PR DESCRIPTION
Trying to reduce the number of `opam` failures due to `safe-string`.

(`arg.opam` file taken from `opam-repository`, could use some love...)